### PR TITLE
fix: remove @libp2p/components

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -34,7 +34,6 @@ export default {
         });
       })))
 
-
       return {
         server,
         env: {

--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ $ npm i @libp2p/webtransport
 ## Libp2p Usage Example
 
 ```js
-import Libp2p from 'libp2p'
-import { WebTransport } from '@libp2p/webtransport'
-import { NOISE } from 'libp2p-noise'
+import { createLibp2pNode } from 'libp2p'
+import { webTransport } from '@libp2p/webtransport'
+import { noise } from 'libp2p-noise'
 
-const node = await Libp2p.create({
-  modules: {
-    connEncryption: [NOISE]
-      transports: [new WebTransport()],
-      connectionEncryption: [new Noise()]
-  },
+const node = await createLibp2pNode({
+  transports: [
+    webTransport()
+  ],
+  connectionEncryption: [
+    noise()
+  ]
 })
 ```
 

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -4,7 +4,7 @@
 import { expect } from 'aegir/chai'
 import { multiaddr } from '@multiformats/multiaddr'
 import { Noise } from '@chainsafe/libp2p-noise'
-import { WebTransport as WebTransportLibp2p, isSubset } from '../src/index'
+import { webTransport, isSubset } from '../src/index'
 import { createLibp2p } from 'libp2p'
 
 declare global {
@@ -19,8 +19,8 @@ describe('libp2p-webtransport', () => {
     const maStr: string = process.env.serverAddr!
     const ma = multiaddr(maStr)
     const node = await createLibp2p({
-      transports: [new WebTransportLibp2p()],
-      connectionEncryption: [new Noise()]
+      transports: [webTransport()],
+      connectionEncryption: [() => new Noise()]
     })
 
     await node.start()
@@ -41,8 +41,8 @@ describe('libp2p-webtransport', () => {
     const ma = multiaddr(maStrNoCerthash + '/p2p/' + maStrP2p)
 
     const node = await createLibp2p({
-      transports: [new WebTransportLibp2p()],
-      connectionEncryption: [new Noise()]
+      transports: [webTransport()],
+      connectionEncryption: [() => new Noise()]
     })
     await node.start()
 


### PR DESCRIPTION
Export factory function that allows constructor injection instead of post-construction initialization.

Technically breaking but this is still yet to be usable with a released version of libp2p so 🤷‍♂️