### PR TITLE
chore: constrain go version examples run with

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: lts/*
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.0'
+          go-version: '1.19.0'
       - name: Install dependencies for webtransport in root
         run: npm install
         working-directory: .


### PR DESCRIPTION
quic-go can't be built on go1.20 so make sure the example tests only run with go1.19.

```
Error:     ../../../../go/pkg/mod/github.com/lucas-clemente/quic-go@v0.31.1/internal/qtls/go120.go:5:13: cannot use "The version of quic-go you're using can't be built on Go 1.20 yet. For more details, please see https://github.com/lucas-clemente/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built on Go 1.20 yet. F...) as int value in variable declaration
```