### PR TITLE
test: ipv6 tests can be skipped if unsupported

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -27,6 +27,7 @@ export default {
       })
       const serverAddr = defer()
       const serverAddr6 = defer()
+      const disableIp6 = process.env.DISABLE_IPV6 != null
 
       server.stdout.on('data', (buf) => {
         const data = buf.toString()
@@ -43,11 +44,13 @@ export default {
         }
       })
 
+
       return {
         server,
         env: {
           serverAddr: await serverAddr.promise,
-          serverAddr6: await serverAddr6.promise
+          serverAddr6: disableIp6 === false ? await serverAddr6.promise : 'skipping',
+          disableIp6
         }
       }
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+## Running tests
+
+Run `npm run test`.
+
+### Running tests without IPv6
+
+If you try to run these tests locally, and your machine does not support IPv6,
+the tests will hang waiting on an ip6 address from the
+`go-libp2p-webtransport-server`.
+
+To get around this, you can set the environment variable `DISABLE_IPV6` to `true`
+to prevent those tests from running. e.g. `DISABLE_IPV6=true npm run test`

--- a/README.md
+++ b/README.md
@@ -91,3 +91,5 @@ Licensed under either of
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+See the [Contributing](./CONTRIBUTING.md) doc for details on developing changes to this repo.

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -101,7 +101,10 @@ describe('libp2p-webtransport', () => {
     await node.stop()
   })
 
-  it('connects to ipv6 addresses', async () => {
+  it('connects to ipv6 addresses', async function () {
+    if (process.env.disableIp6 === 'true') {
+      return this.skip()
+    }
     if (process.env.serverAddr6 == null) {
       throw new Error('serverAddr6 not found')
     }


### PR DESCRIPTION
Allows disabling of running ipv6 tests. On machines without ipv6 support, the tests hang forever. This means users without ipv6 (I suspect most CenturyLink ISP users) could not run tests before this change.

* Adds toggle for ipv6 tests based on `DISABLE_IPV6` env var. 
* CONTRIBUTING.md is also being added to mention the scenario I ran into.

**Note:** When running the tests, and aegir times out on serverAddr6.promise, it should fail, but it doesn't.